### PR TITLE
allow might on hunters(survival - twow 1.17.2 update)

### DIFF
--- a/PallyPower.lua
+++ b/PallyPower.lua
@@ -847,7 +847,7 @@ function PallyPower_NeedsBuff(class, test)
         --    return false
         --end
         -- no might for casters
-        if (class == 2 or class == 5 or class == 6 or class == 7) and test == 1 then
+        if (class == 2 or class == 6 or class == 7) and test == 1 then
             return false
         end
     end


### PR DESCRIPTION
with 1.17.2 survival hunter use melee and prefer might instead of wisdom